### PR TITLE
fix: add undeclared LogPath and EnableDebugMode params to Deploy-ScheduledTasks.ps1

### DIFF
--- a/Scripts/TaskScheduler/Deploy-ScheduledTasks.ps1
+++ b/Scripts/TaskScheduler/Deploy-ScheduledTasks.ps1
@@ -56,24 +56,40 @@
 #>
 
 [CmdletBinding(SupportsShouldProcess)]
+[System.Diagnostics.CodeAnalysis.SuppressMessage('PSReviewUnusedParameter', 'EnableDebugMode', Justification = 'Used in Write-ScriptLog function scope')]
 param (
     [Parameter(Mandatory = $true)]
     [string]$TaskName,
-    
+
     [Parameter(Mandatory = $true)]
     [string[]]$ServerList,
-    
+
     [Parameter(Mandatory = $true)]
     [string[]]$FilesToCopy,
-    
+
     [Parameter(Mandatory = $false)]
     [string]$TargetDirectory = "C:\Scripts",
-    
+
     [Parameter(Mandatory = $false)]
-    [switch]$ExecuteAfterRegister
+    [switch]$ExecuteAfterRegister,
+
+    [Parameter(Mandatory = $false)]
+    [string]$LogPath = "C:\Logs",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$EnableDebugMode
 )
 
 $ErrorActionPreference = 'Stop'
+
+$script:LogFilePath = $null
+if ($LogPath) {
+    if (-not (Test-Path $LogPath)) {
+        New-Item -Path $LogPath -ItemType Directory -Force | Out-Null
+    }
+    $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $script:LogFilePath = Join-Path $LogPath "Deploy-ScheduledTasks_${timestamp}.log"
+}
 
 function Write-ScriptLog {
     param(
@@ -81,15 +97,19 @@ function Write-ScriptLog {
         [ValidateSet('Info', 'Warning', 'Error', 'Debug')]
         [string]$Level = 'Info'
     )
-    
+
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
     $logMessage = "[$timestamp] [$Level] $Message"
-    
+
     switch ($Level) {
         'Info' { Write-Information $logMessage -InformationAction Continue }
         'Warning' { Write-Warning $logMessage }
         'Error' { Write-Error $logMessage }
-        'Debug' { Write-Verbose $logMessage }
+        'Debug' { if ($EnableDebugMode) { Write-Verbose $logMessage } }
+    }
+
+    if ($script:LogFilePath) {
+        $logMessage | Out-File -FilePath $script:LogFilePath -Append -Encoding UTF8
     }
 }
 


### PR DESCRIPTION
These parameters were documented in the help block and README but missing from the param() block, causing runtime errors when used.

Closes #2