### PR TITLE
fix: correct WhatIf check in Disable-LanmanCache.ps1

### DIFF
--- a/Scripts/Registry/Disable-LanmanCache.ps1
+++ b/Scripts/Registry/Disable-LanmanCache.ps1
@@ -102,7 +102,7 @@ try {
     Write-Information "LanmanWorkstation cache settings have been disabled successfully." -InformationAction Continue
     Write-Warning "IMPORTANT: A system restart may be required for changes to take effect."
     
-    if (-not $WhatIf) {
+    if (-not $WhatIfPreference) {
         $restart = Read-Host "`nWould you like to restart the computer now? (y/N)"
         if ($restart -eq 'y' -or $restart -eq 'Y') {
             Write-Information "Initiating system restart..." -InformationAction Continue


### PR DESCRIPTION
Replace undeclared $WhatIf variable with $WhatIfPreference automatic variable so the restart prompt is properly suppressed during -WhatIf runs.

Closes #3